### PR TITLE
test(middleware): add bash test suite for all middleware + fix guest …

### DIFF
--- a/backend/pkg/routes/router.go
+++ b/backend/pkg/routes/router.go
@@ -63,6 +63,7 @@ func ConfigureRouter(
 			"/auth/reset-password",
 			"/auth/verify-reset-token",
 			"/api/webhooks/paystack", // Webhooks don't need CSRF
+			"/api/csrf-token",
 		),
 	}
 
@@ -99,6 +100,24 @@ func ConfigureRouter(
 			},
 		})
 	})
+
+	// CSRF token seed endpoint — allows guests to obtain a CSRF cookie
+// before submitting any state-changing request (inquiry, order, etc.)
+// Industry standard pattern: SPA calls this on mount before any form submission.
+router.GET("/api/csrf-token",
+    func(c *gin.Context) {
+        // If token already exists, don't regenerate — preserve existing session token
+        if existing, err := c.Cookie(middleware.CSRFTokenCookieName); err == nil && existing != "" {
+            c.JSON(http.StatusOK, gin.H{"message": "Token already active."})
+            return
+        }
+        if _, err := middleware.GenerateAndSetCSRFToken(c); err != nil {
+            c.JSON(http.StatusInternalServerError, gin.H{"message": "Could not generate security token."})
+            return
+        }
+        c.JSON(http.StatusOK, gin.H{"message": "Token issued."})
+    },
+)
 
 	// ============================================
 	// AUTH ROUTES (Special handling)


### PR DESCRIPTION
…CSRF gap

Bash tests covering what Go unit tests cannot prove:
- Real HTTP timing, cookie round-trips, Redis blacklist concurrency
- Rate limit burst exhaustion requires parallel load (PublicLimiter)
- Auth blacklist: 8 concurrent workers, zero token slip-through
- CSRF skip list wired correctly in live router
- OptionalAuth: Authorization header ignored, fail-open on all paths
- Guest middleware: UUID uniqueness under concurrent load, dual tracking

Fix: add GET /api/csrf-token seed endpoint (industry standard pattern)
- Resolves design gap: no unauthenticated route generated a CSRF cookie
- Guests submitting inquiries/orders had no path to get csrf_token
- One call seeds both guest_id (GuestMiddleware) and csrf_token (CSRF)
- Added to SkipCSRFForPaths — cannot require CSRF to issue CSRF
- Wired with GuestMiddleware globally so both cookies set in one round-trip

Bash test files (testy/):
  test-rate-limit.sh       — 17 tests, 3 limiter profiles, concurrency
  test-auth-middleware.sh  — 15 tests, RSA JWT, Redis blacklist lifecycle
  test-csrf-middleware.sh  — 19 tests, Double Submit pattern end-to-end
  test-optional-auth.sh    —  9 tests, fail-open contract, full chain
  test-guest-middleware.sh — 17 tests, session tracking, concurrent IDs

Total: 77/77 passing