### PR TITLE
fix(middleware): patch security vulnerabilities and harden token vali…

### DIFF
--- a/frontend/src/middleware.js
+++ b/frontend/src/middleware.js
@@ -2,6 +2,16 @@
 import { NextResponse } from "next/server";
 import { jwtDecode } from "jwt-decode";
 
+// ─── Dev-only logging ─────────────────────────────────────────────────────────
+// Suppressed in production to avoid log noise and Edge runtime overhead.
+const devLog = (...args) =>
+  process.env.NODE_ENV !== "production" && console.log(...args);
+
+const devError = (...args) =>
+  process.env.NODE_ENV !== "production" && console.error(...args);
+
+// ─── Route lists ──────────────────────────────────────────────────────────────
+
 const PROTECTED_UI_ROUTES = [
   "/dashboard",
   "/profile",
@@ -21,12 +31,17 @@ const PUBLIC_UI_ROUTES = [
   "/confirmation",
   "/events/[slug]",
   "/vendors/[id]",
-  "/api/*-image",
-  "/api/v1/feedback",
+  "/api/event-image",
   "/api/feedback-image",
+  "/api/vendor-image",
+  "/api/v1/feedback",
   "/api/feedback",
 ];
 
+// NOTE: "/api/v1/vendors" here causes all sub-paths (/api/v1/vendors/admin, etc.)
+// to be treated as public via prefix matching. This is intentional only if the
+// backend API layer enforces its own auth on protected sub-routes. If middleware-
+// level protection is needed, remove this entry and list sub-paths explicitly.
 const PUBLIC_API_ROUTES = [
   "/auth/signup",
   "/auth/login",
@@ -46,6 +61,10 @@ const PUBLIC_API_ROUTES = [
   "/api/webhooks/paystack",
 ];
 
+// ─── Token validation ─────────────────────────────────────────────────────────
+// Returns the decoded JWT payload on success, false on any failure.
+// Returning the payload (not a boolean) lets callers reuse it — avoids a
+// second jwtDecode call in the default handler.
 function isTokenValid(token) {
   if (!token) return false;
 
@@ -53,22 +72,24 @@ function isTokenValid(token) {
     const decoded = jwtDecode(token);
     const now = Date.now() / 1000;
 
-    if (decoded.exp && decoded.exp < now) {
-      return false;
-    }
+    if (decoded.exp == null) return false;
+    if (decoded.exp < now) return false;
 
-    return true;
+    return decoded;
   } catch (error) {
-    console.error("[Middleware] Token validation error:", error);
+    devError("[Middleware] Token validation error:", error);
     return false;
   }
 }
 
+// Returns the decoded token payload if authenticated, false otherwise.
 function isAuthenticated(request) {
   const accessToken = request.cookies.get("access_token")?.value;
   if (!accessToken) return false;
   return isTokenValid(accessToken);
 }
+
+// ─── Route matching ───────────────────────────────────────────────────────────
 
 function matchesRoute(pathname, routes) {
   return routes.some((route) => {
@@ -92,42 +113,51 @@ function matchesRoute(pathname, routes) {
   });
 }
 
+// ─── Middleware ───────────────────────────────────────────────────────────────
+
 export function middleware(request) {
   const { pathname } = request.nextUrl;
-  const hasValidToken = isAuthenticated(request);
 
-  console.log("🔒 [MIDDLEWARE] Request", {
+  // decodedToken is the JWT payload on success, false on any auth failure.
+  // Thread it through to the default handler — no second jwtDecode call needed.
+  const decodedToken = isAuthenticated(request);
+  const hasValidToken = !!decodedToken;
+
+  devLog("🔒 [MIDDLEWARE] Request", {
     path: pathname,
     hasToken: !!request.cookies.get("access_token"),
     tokenValid: hasValidToken,
   });
 
-  // Auth routes - redirect if already authenticated
+  // ── Auth routes — redirect authenticated users away ────────────────────────
   if (matchesRoute(pathname, AUTH_ROUTES)) {
     if (hasValidToken) {
-      console.log(
+      devLog(
         "🔄 [MIDDLEWARE] Already authenticated - Redirecting to dashboard",
       );
+      const rawCallback = request.nextUrl.searchParams.get("callbackUrl");
+      // Only accept paths that start with exactly one /
+      // Rejects: https://evil.com  //evil.com  /  (bare slash)  empty string
       const redirectUrl =
-        request.nextUrl.searchParams.get("callbackUrl") || "/dashboard";
+        rawCallback && /^\/[^/]/.test(rawCallback) ? rawCallback : "/dashboard";
       return NextResponse.redirect(new URL(redirectUrl, request.url));
     }
-    console.log("✅ [MIDDLEWARE] Auth route - Allowing access");
+    devLog("✅ [MIDDLEWARE] Auth route - Allowing access");
     return NextResponse.next();
   }
 
-  // Public API routes
+  // ── Public API routes ──────────────────────────────────────────────────────
   if (pathname.startsWith("/api") || pathname.startsWith("/auth")) {
     if (matchesRoute(pathname, PUBLIC_API_ROUTES)) {
-      console.log("🌐 [MIDDLEWARE] Public API route - Allowing access");
+      devLog("🌐 [MIDDLEWARE] Public API route - Allowing access");
       return NextResponse.next();
     }
   }
 
-  // Protected UI routes - require valid token
+  // ── Protected UI routes — require valid token ──────────────────────────────
   if (matchesRoute(pathname, PROTECTED_UI_ROUTES)) {
     if (!hasValidToken) {
-      console.log("❌ [MIDDLEWARE] No valid token - Redirecting to login");
+      devLog("❌ [MIDDLEWARE] No valid token - Redirecting to login");
       const loginUrl = new URL("/account/auth/login", request.url);
       loginUrl.searchParams.set("callbackUrl", pathname);
 
@@ -138,39 +168,40 @@ export function middleware(request) {
       if (hasExpiredToken) {
         response.cookies.delete("access_token");
         response.cookies.delete("refresh_token");
-        console.log("🧹 [MIDDLEWARE] Cleared expired token cookies");
+        devLog("🧹 [MIDDLEWARE] Cleared expired token cookies");
       }
 
       return response;
     }
-    console.log("✅ [MIDDLEWARE] Protected UI route - Authorized");
+    devLog("✅ [MIDDLEWARE] Protected UI route - Authorized");
     return NextResponse.next();
   }
 
-  // Public UI routes
+  // ── Public UI routes ───────────────────────────────────────────────────────
   if (matchesRoute(pathname, PUBLIC_UI_ROUTES)) {
-    console.log("🌐 [MIDDLEWARE] Public UI route - Allowing access");
+    devLog("🌐 [MIDDLEWARE] Public UI route - Allowing access");
     return NextResponse.next();
   }
 
-  // Default - pass through with user ID header
+  // ── Default — inject user ID request header + apply security headers ───────
   const requestHeaders = new Headers(request.headers);
-  const token = request.cookies.get("access_token")?.value;
 
-  if (token && hasValidToken) {
-    try {
-      const decoded = jwtDecode(token);
-      requestHeaders.set("x-user-id", decoded.user_id);
-    } catch (error) {
-      console.error("[Middleware] Failed to decode token:", error);
-    }
+  // Use the already-decoded payload — no second jwtDecode call.
+  if (decodedToken && decodedToken.user_id) {
+    requestHeaders.set("x-user-id", String(decodedToken.user_id));
   }
 
-  return NextResponse.next({
-    request: {
-      headers: requestHeaders,
-    },
+  const response = NextResponse.next({
+    request: { headers: requestHeaders },
   });
+
+  // Security response headers.
+  // TODO: lift to a shared helper when auth/public routes also need these.
+  response.headers.set("X-Frame-Options", "DENY");
+  response.headers.set("X-Content-Type-Options", "nosniff");
+  response.headers.set("Referrer-Policy", "strict-origin-when-cross-origin");
+
+  return response;
 }
 
 export const config = {


### PR DESCRIPTION
…dation

Fixes:
- Replace dead wildcard '/api/*-image' with explicit image routes in PUBLIC_UI_ROUTES (/api/event-image, /api/feedback-image, /api/vendor-image)
- Fix open redirect: validate callbackUrl against /^\/[^/]/ before redirect — rejects absolute URLs, protocol-relative (//evil.com), and bare slash
- Fix exp=0 bypass: replace falsy 'decoded.exp && decoded.exp < now' guard with two explicit checks — 'decoded.exp == null' and 'decoded.exp < now'
- Reject tokens with no exp field (previously accepted indefinitely)

Refactor:
- isTokenValid now returns decoded payload (not boolean) — eliminates double jwtDecode call in default handler; user_id injected from first decode only
- Add decodedToken.user_id guard — prevents header being set to string 'undefined'
- Gate all console.log/error behind NODE_ENV !== 'production' via devLog/devError

Security:
- Add X-Frame-Options: DENY, X-Content-Type-Options: nosniff, and Referrer-Policy: strict-origin-when-cross-origin to default handler responses

Tests (middleware.test.js): 42 → 69 passing
- Section A: add exp=0 as standalone token case
- Section B: rename misleading wildcard test; add /vendors/[id] dynamic segment
- Section C: add /contact, /vendors/123, authenticated users on public routes, full it.each for public API routes, route evaluation order assertion
- Section D: add bare-slash callbackUrl case, valid callbackUrl round-trip
- Section E: image routes now assert PUBLIC_UI_ROUTES handler ran (requestHeaders: null)
- Section G: add user_id undefined header injection case
- Section H: new — four security response header assertions

Tooling (middleware-gaps.sh): rewritten from 'expose bugs' to 'verify fixes'
- Now greps src/middleware.js directly — 17/17 green against patched source
- Checks: wildcard removal, rawCallback guard, exp guards, single jwtDecode, NODE_ENV guard, security headers, route reachability, matcher regex, vendor prefix collision documentation